### PR TITLE
家計データ編集時に金額がカンマを含まない数値として表示されるように修正しました。

### DIFF
--- a/MainApplication/DataManager.cs
+++ b/MainApplication/DataManager.cs
@@ -663,6 +663,30 @@ namespace MainApplication
             }
         }
 
+        public int AmountString2Int(string s)
+        {
+            if (string.IsNullOrEmpty(s) == true)
+            {
+                throw new ArgumentNullException("s");
+            }
+
+            int output = -1;
+
+            IFormatProvider provider = CultureInfo.CreateSpecificCulture("en-US");
+            if (Int32.TryParse(
+                    s,
+                    NumberStyles.Integer | NumberStyles.AllowThousands,
+                    provider,
+                    out output
+                    ) == false
+                )
+            {
+                throw new ArgumentException("s");
+            }
+
+            return output;
+        }
+
         #endregion
 
         #region プライベートメソッド
@@ -711,30 +735,6 @@ namespace MainApplication
             _command.CommandText = "insert into アプリ設定 (設定項目,設定値) values ";
             _command.CommandText += "('金額の区切り文字','+'),('コメントの区切り文字',':')";
             _command.ExecuteNonQuery();
-        }
-
-        private int AmountString2Int(string s)
-        {
-            if (string.IsNullOrEmpty(s) == true)
-            {
-                throw new ArgumentNullException("s");
-            }
-
-            int output = -1;
-
-            IFormatProvider provider = CultureInfo.CreateSpecificCulture("en-US");
-            if (Int32.TryParse(
-                    s,
-                    NumberStyles.Integer | NumberStyles.AllowThousands,
-                    provider,
-                    out output
-                    ) == false
-                )
-            {
-                throw new ArgumentException("s");
-            }
-
-            return output;
         }
 
         #endregion

--- a/MainApplication/MainForm.cs
+++ b/MainApplication/MainForm.cs
@@ -619,7 +619,23 @@ namespace MainApplication
             this.textBox_EditAmount.BringToFront();
 
             // 現在登録されている金額をテキストボックスに表示する。
-            this.textBox_EditAmount.Text = (string)this.listBox_AmountsDetail.SelectedItem;
+            int amount = -1;
+            string comment = "";
+            string[] splittedString = ((string)this.listBox_AmountsDetail.SelectedItem).Split(_settings.commentSplitCharacter);
+            switch (splittedString.Length)
+            {
+                case 1:
+                    amount = _dataManager.AmountString2Int(splittedString[0]);
+                    break;
+                case 2:
+                    amount = _dataManager.AmountString2Int(splittedString[0]);
+                    comment = splittedString[1];
+                    break;
+                default:
+                    throw new Exception("登録されている金額情報の形式が不正です。");
+            }
+
+            this.textBox_EditAmount.Text = amount.ToString() + _settings.commentSplitCharacter.ToString() + comment;
 
             this.textBox_EditAmount.Visible = true;
 


### PR DESCRIPTION
家計データ編集時に金額がカンマ区切りになっていた現象を修正し，カンマを含まない数値として表示するようにしました。
DataManagerクラスのAmountString2Intメソッドをprivateからpublicに変更し，他クラスから使用できるようにしました。
Close #7
